### PR TITLE
v1.0.0.ToDataURLServer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ node_modules
 /.vs/slnx.sqlite
 /.vs/VSWorkspaceState.json
 /src/.vs/Blazor.SignaturePad/v16/.suo
+/src/.vs/Blazor.SignaturePad/DesignTimeBuild/.dtbcache.v2
+/src/Blazor.SignaturePad.csproj.vspscc
+/src/Blazor.SignaturePad.sln

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ obj
 pub
 test
 node_modules
+/.vs/Blazor.SignaturePad/v16/.suo
+/.vs/ProjectSettings.json
+/.vs/slnx.sqlite
+/.vs/VSWorkspaceState.json
+/src/.vs/Blazor.SignaturePad/v16/.suo

--- a/src/Blazor/SignaturePad.razor.cs
+++ b/src/Blazor/SignaturePad.razor.cs
@@ -4,6 +4,7 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 using System.Threading.Tasks;
+using System;
 
 namespace Mobsites.Blazor
 {
@@ -80,6 +81,41 @@ namespace Mobsites.Blazor
             "Mobsites.Blazor.SignaturePad.toDataURL",
             type.ToString())
             .AsTask();
+        /// <summary>
+        /// Get signature as data url according to the supported type.
+        /// </summary>
+        public async Task<string> ToDataURLServer(SupportedSaveAsTypes type)
+        {
+            //DataUploader uploader = new DataUploader(jsRuntime);
+            ////StreamReader streamReader = new StreamReader(await uploader.ReceiveData(9999999, type.ToString()));
+            //string rtn = await uploader.ReceiveData(9999999, type.ToString());
+            //return rtn;
+
+            int _segmentSize = 24576;
+
+            var fileSize = await jsRuntime.InvokeAsync<int>("Mobsites.Blazor.SignaturePad.getDataSize", type.ToString());
+
+            string rtnData = "";
+
+            var numberOfSegments = Math.Floor(fileSize / (double)_segmentSize) + 1;
+            string segmentData;
+
+            for (var i = 0; i < numberOfSegments; i++)
+            {
+                try
+                {
+                    segmentData = await jsRuntime.InvokeAsync<string>(
+                            "Mobsites.Blazor.SignaturePad.receiveSegment", i, type.ToString());
+
+                }
+                catch
+                {
+                    return null;
+                }
+                rtnData = rtnData + segmentData;
+            }
+            return rtnData;
+        }
 
         /// <summary>
         /// Invoked from a javascript callback event when a signature changes in some way.

--- a/src/app.js
+++ b/src/app.js
@@ -153,5 +153,25 @@ window.Mobsites.Blazor.SignaturePad = {
     a.target = '_blank'
     document.body.appendChild(a);
     a.click();
-  }
+    },
+  getDataSize: function (type) {
+        var dataURL = this.toDataURL(type);
+        if (dataURL == null) {
+            return 0;
+        }
+        var dataSize = dataURL.length;
+        return dataSize;
+    },
+  receiveSegment: function (segmentNumber, type) {
+        var dataURL = this.toDataURL(type);
+        var index = segmentNumber * 24576;
+        return getNextChunk(dataURL, index);
+    }
+}
+
+function getNextChunk(dataURL, index) {
+    const length = dataURL.length - index <= 24576 ? dataURL.length - index : 24576;
+    const chunk = dataURL.substring(index, index + length);
+    index += length;
+    return chunk;
 }

--- a/src/app.js
+++ b/src/app.js
@@ -155,23 +155,23 @@ window.Mobsites.Blazor.SignaturePad = {
     a.click();
     },
   getDataSize: function (type) {
-        var dataURL = this.toDataURL(type);
-        if (dataURL == null) {
-            return 0;
-        }
-        var dataSize = dataURL.length;
-        return dataSize;
+    var dataURL = this.toDataURL(type);
+    if (dataURL == null) {
+        return 0;
+    }
+    var dataSize = dataURL.length;
+    return dataSize;
     },
   receiveSegment: function (segmentNumber, type) {
-        var dataURL = this.toDataURL(type);
-        var index = segmentNumber * 24576;
-        return getNextChunk(dataURL, index);
-    }
-}
-
-function getNextChunk(dataURL, index) {
+    var dataURL = this.toDataURL(type);
+    var index = segmentNumber * 24576;
+    return this.getNextChunk(dataURL, index);
+    },
+  getNextChunk: function (dataURL, index) {
     const length = dataURL.length - index <= 24576 ? dataURL.length - index : 24576;
     const chunk = dataURL.substring(index, index + length);
     index += length;
     return chunk;
+    }
 }
+


### PR DESCRIPTION
Pull request to merge Mike's changes to fix message limitation error on Blazor Server when calling the toDataURL() method where signature is complex and, therefore, exceeds limit.